### PR TITLE
Feature/qfeed-52 #10 피드백 반영 및 의존성 리팩토링

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,17 @@ subprojects {
 	jar {
 		enabled = true
 	}
+
+	// spring ai 설정
+	ext {
+		springAiVersion = "1.0.0-M4"
+	}
+
+	dependencyManagement {
+		imports {
+			mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
+		}
+	}
 }
 
 // module-api만 실행 가능한 Spring Boot JAR 파일 생성

--- a/module-application/build.gradle
+++ b/module-application/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	implementation project(':module-domain')
 	implementation project(':module-infra')
 	implementation project(':module-common')
+	implementation project(':module-external-api')
 
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
@@ -3,9 +3,10 @@ package com.wsws.moduleapplication.feed.service;
 import com.wsws.moduledomain.category.Category;
 import com.wsws.moduledomain.category.repo.CategoryRepository;
 import com.wsws.moduledomain.feed.question.Question;
+import com.wsws.moduledomain.feed.question.ai.VectorClient;
 import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
-import com.wsws.moduleexternalapi.feed.client.RedisVectorClient;
+import com.wsws.moduleexternalapi.feed.client.VectorClientImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -20,7 +21,7 @@ import java.util.Map;
 @Slf4j
 public class QuestionAIService {
 
-    private final RedisVectorClient redisVectorClient;
+    private final VectorClient vectorClient;
     private final QuestionRepository questionRepository;
     private final CategoryRepository categoryRepository;
 
@@ -51,7 +52,7 @@ public class QuestionAIService {
         }
 
         // 벡터 데이터베이스에 질문 저장
-        redisVectorClient.store(questionTempStore.values().stream().toList());
+        vectorClient.store(questionTempStore.values().stream().toList());
 
 
     }

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
@@ -1,0 +1,69 @@
+package com.wsws.moduleapplication.feed.service;
+
+import com.wsws.moduledomain.category.Category;
+import com.wsws.moduledomain.category.repo.CategoryRepository;
+import com.wsws.moduledomain.feed.question.Question;
+import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
+import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
+import com.wsws.moduleexternalapi.feed.client.RedisVectorClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class QuestionAIService {
+
+    private final RedisVectorClient redisVectorClient;
+    private final QuestionRepository questionRepository;
+    private final CategoryRepository categoryRepository;
+
+    /**
+     * 데이터베이스에 질문 저장
+     * 질문 저장은 모든 질문들의 검증이 끝난 후에 이루어진다.
+     * -> 저장해야하는 데이터베이스가 두 개이기 때문에 데이터 불일치를 방지하기 위함.
+     */
+    @Transactional
+    public void saveQuestions(Map<String, String> questionTempStore) {
+        log.info("데이터베이스에 질문을 저장");
+
+        List<Category> categoryList = categoryRepository.findAll(); // 카테고리 전부 로드
+        // RDBMS에 질문 저장
+        for (String categoryName : questionTempStore.keySet()) {
+            Category category = categoryList.stream()
+                    .filter(c -> categoryName.equals(c.getCategoryName().name()))
+                    .findFirst().orElseThrow(() -> new RuntimeException("Category not found: " + categoryName));
+
+            questionRepository.save(
+                    Question.create(
+                            questionTempStore.get(categoryName),
+                            QuestionStatus.CREATED,
+                            LocalDateTime.now(),
+                            category.getId()
+                    )
+            );
+        }
+
+        // 벡터 데이터베이스에 질문 저장
+        redisVectorClient.store(questionTempStore.values().stream().toList());
+
+
+    }
+
+    @Transactional
+    public void updateQuestions() {
+        // 어제 질문들 비활성화
+        questionRepository.findByQuestionStatus(QuestionStatus.ACTIVATED)
+                .forEach(Question::inactivateQuestion);
+
+        // 오늘 질문들 활성화
+        questionRepository.findByQuestionStatus(QuestionStatus.CREATED)
+                .forEach(Question::activateQuestion);
+    }
+}

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
@@ -36,7 +36,7 @@ public class QuestionAIService {
     public void saveQuestions(Map<String, String> questionTempStore) {
         log.info("데이터베이스에 질문을 저장");
 
-        List<Category> categoryList = categoryRepository.findAll(); // 카테고리 전부 로드
+        List<Category> categoryList = categoryRepository.findAllCategories(); // 카테고리 전부 로드
         // RDBMS에 질문 저장
         for (String categoryName : questionTempStore.keySet()) {
             Category category = categoryList.stream()

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/QuestionAIService.java
@@ -6,7 +6,6 @@ import com.wsws.moduledomain.feed.question.Question;
 import com.wsws.moduledomain.feed.question.ai.VectorClient;
 import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
-import com.wsws.moduleexternalapi.feed.client.VectorClientImpl;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -12,8 +12,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.*;
-import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.getTotalToken;
 
 @Service
 @RequiredArgsConstructor
@@ -62,7 +60,7 @@ public class ScheduledQuestionCreateService {
                 }
                 log.info("모든 질문 생성완료.");
                 questionAIService.saveQuestions(questionTempStore);
-                log.info(" 사용된 누적 토큰 수: [입력토큰: {}, 출력토큰: {}, 총합: {}]", getPromptToken(), getGenerationToken(), getTotalToken());
+                log.info(" 사용된 누적 토큰 수: [입력토큰: {}, 출력토큰: {}, 총합: {}]", questionGenerateClient.getGenerationTokens(), questionGenerateClient.getPromptTokens(), questionGenerateClient.getTotalTokens());
                 break; // 성공 시 루프 종료
             } catch (Exception e) {
                 log.error("createQuestion 실패. 시도 횟수: {}", attempt, e);

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -1,9 +1,8 @@
 package com.wsws.moduleapplication.feed.service.scheduler;
 
 import com.wsws.moduleapplication.feed.service.QuestionAIService;
-import com.wsws.moduledomain.category.vo.CategoryName;
-import com.wsws.moduleexternalapi.feed.client.QuestionGenerateClient;
-import com.wsws.moduleexternalapi.feed.client.RedisVectorClient;
+import com.wsws.moduledomain.feed.question.ai.QuestionGenerateClient;
+import com.wsws.moduledomain.feed.question.ai.VectorClient;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -13,8 +12,6 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
-import static com.wsws.moduledomain.category.vo.CategoryName.DELICIOUS_RESTAURANT;
-import static com.wsws.moduledomain.category.vo.CategoryName.TRAVEL;
 import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.*;
 import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.getTotalToken;
 
@@ -23,7 +20,7 @@ import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.getTotalTo
 @Slf4j
 public class ScheduledQuestionCreateService {
 
-    private final RedisVectorClient redisVectorClient; // 벡터 데이터베이스
+    private final VectorClient redisVectorClient; // 벡터 데이터베이스
     private final QuestionGenerateClient questionGenerateClient; // 질문 생성 AI
     private final QuestionAIService questionAIService; // 새로 분리된 서비스
 

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 import static com.wsws.moduledomain.category.vo.CategoryName.*;
 import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.*;
@@ -81,9 +83,9 @@ public class ScheduledQuestionCreateService {
      * 카테고리 리스트 초기화
      */
     private void initList() {
-        categories = new ArrayList<>(List.of(TRAVEL.name(), DELICIOUS_RESTAURANT.name(), MOVIE.name(), MUSIC.name(), READING.name(), SPORTS.name()));
-        questionBlackListMap = new HashMap<>();
-        questionTempStore = new HashMap<>();
+        categories = new CopyOnWriteArrayList<>(List.of());
+        questionBlackListMap = new ConcurrentHashMap<>();
+        questionTempStore = new ConcurrentHashMap<>();
     }
 
     /**

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -97,10 +97,17 @@ public class ScheduledQuestionCreateService {
         // 벡터 데이터베이스에 질문 저장
         redisVectorClient.store(questionTempStore.values().stream().toList());
 
+        List<Category> categoryList = categoryRepository.findAll(); // 카테고리를 전부 받아옴.
+
         // RDBMS에 질문 저장
-        for (String c : questionTempStore.keySet()) {
-            Category category = categoryRepository.findByCategoryName(CategoryName.valueOf(c)); // 카테고리에 ID를 받아옴.
-            questionRepository.save(Question.create(questionTempStore.get(c), QuestionStatus.CREATED, LocalDateTime.now(), category.getId())); // Question 엔티티 RDBMS에 저장
+        for (String categoryName : questionTempStore.keySet()) {
+
+            Category category = categoryList.stream()
+                    .filter(c -> categoryName.equals(c.getCategoryName().name()))
+                    .findFirst().orElseThrow(RuntimeException::new); // 해당 카테고리이름의 카테고리 객체를 찾음
+
+            questionRepository.save(
+                    Question.create(questionTempStore.get(categoryName), QuestionStatus.CREATED, LocalDateTime.now(), category.getId())); // Question 엔티티 RDBMS에 저장
         }
     }
 

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -1,0 +1,102 @@
+package com.wsws.moduleapplication.feed.service.scheduler;
+
+import com.wsws.moduledomain.category.Category;
+import com.wsws.moduledomain.category.repo.CategoryRepository;
+import com.wsws.moduledomain.category.vo.CategoryName;
+import com.wsws.moduledomain.feed.question.Question;
+import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
+import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
+import com.wsws.moduleexternalapi.feed.client.QuestionGenerateClient;
+import com.wsws.moduleexternalapi.feed.client.RedisVectorClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static com.wsws.moduledomain.category.vo.CategoryName.*;
+import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class ScheduledQuestionCreateService {
+
+    private final RedisVectorClient redisVectorClient; // 벡터 데이터베이스
+    private final QuestionGenerateClient questionGenerateClient; // 질문 생성 AI
+    private final QuestionRepository questionRepository;
+    private final CategoryRepository categoryRepository;
+
+    private List<String> categories;
+    private Map<String, List<String>> questionBlackList;
+
+    /**
+     * 매일 23시 30분에 질문을 생성
+     */
+    @Scheduled(cron = "0 30 23 * * ?")
+    public void createQuestion() {
+        initList(); // 리스트 초기화
+
+        // 모든 카테고리의 질문들이 생성될 때 까지 반복
+        while(!categories.isEmpty()) {
+            Map<String, String> createdQuestions = questionGenerateClient.createQuestions(categories, questionBlackList);
+
+            // 질문 검증 및 저장
+            for (String categoryName : createdQuestions.keySet()) {
+                String question = createdQuestions.get(categoryName);
+                List<String> similarQuestions = redisVectorClient.findSimilarText(question);
+
+                if (similarQuestions.isEmpty()) { // 중복되지 않는 질문일 때,
+                    saveQuestion(categoryName, question); // 데이터베이스에 질문 저장
+                } else { // 중복된 질문이면
+                    // 질문 블랙 리스트에 추가
+                    log.info("질문 중복: {}: {}", categoryName, question);
+                    if(questionBlackList.containsKey(categoryName)) { // 생성된 질문 블랙리스트에 저장
+                        questionBlackList.get(categoryName).add(question);
+                    } else {
+                        questionBlackList.put(categoryName, new ArrayList<>(List.of(question)));
+                    }
+                    questionBlackList.get(categoryName).addAll(similarQuestions); // 중복된 질문들을 블랙 리스트에 저장
+                }
+            }
+        }
+        log.info("모든 질문 생성완료. 사용된 누적 토큰 수: [입력토큰: {}, 출력토큰: {}, 총합: {}", getPromptToken(), getGenerationToken(), getTotalToken());
+    }
+
+
+    /**
+     * 카테고리 리스트 초기화
+     */
+    private void initList() {
+        categories = new ArrayList<>(List.of(TRAVEL.name(), DELICIOUS_RESTAURANT.name(), MOVIE.name(), MUSIC.name(), READING.name(), SPORTS.name()));
+        questionBlackList = new HashMap<>();
+    }
+
+    /**
+     * 데이터베이스에 질문 저장
+     */
+    private void saveQuestion(String categoryName, String question) {
+        redisVectorClient.store(question); // 벡터 데이터베이스에 질문 저장
+        Category category = categoryRepository.findByCategoryName(CategoryName.valueOf(categoryName));
+        questionRepository.save(Question.create(question, QuestionStatus.CREATED, LocalDateTime.now(), category.getId())); // Question 엔티티 RDBMS에 저장
+
+        removeList(categoryName); // 저장한 질문의 카테고리는 리스트에서 제외
+    }
+
+    /**
+     * 해당 카테고리 리스트에서 제외
+     */
+    private void removeList(String categoryName) {
+        categories.remove(categoryName);
+        questionBlackList.remove(categoryName);
+    }
+
+
+}

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -53,6 +53,7 @@ public class ScheduledQuestionCreateService {
                 String question = createdQuestions.get(categoryName);
                 List<String> similarQuestions = redisVectorClient.findSimilarText(question);
 
+
                 if (similarQuestions.isEmpty()) { // 중복되지 않는 질문일 때,
                     log.info("질문 검증 완료: {}: {}", categoryName, question);
                     questionTempStore.put(categoryName, question); // 질문 리스트에 임시 저장
@@ -70,11 +71,7 @@ public class ScheduledQuestionCreateService {
     }
 
     private void addQuestionsToBlackListMap(String categoryName, String question, List<String> similarQuestions) {
-        if (questionBlackListMap.containsKey(categoryName)) { // 생성된 질문 블랙리스트에 저장
-            questionBlackListMap.get(categoryName).add(question);
-        } else {
-            questionBlackListMap.put(categoryName, new HashSet<>(Set.of(question)));
-        }
+        questionBlackListMap.computeIfAbsent(categoryName, k -> new HashSet<>()).add(question);
         questionBlackListMap.get(categoryName).addAll(similarQuestions); // 중복된 질문들을 블랙 리스트에 저장
     }
 

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import static com.wsws.moduledomain.category.vo.CategoryName.DELICIOUS_RESTAURANT;
 import static com.wsws.moduledomain.category.vo.CategoryName.TRAVEL;
 import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.*;
+import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.getTotalToken;
 
 @Service
 @RequiredArgsConstructor
@@ -44,6 +45,7 @@ public class ScheduledQuestionCreateService {
                 attempt++;
                 initList(); // 리스트 초기화
 
+                // TODO: while문을 빠져나올 조건
                 while (!categories.isEmpty()) {
                     Map<String, String> createdQuestions = questionGenerateClient.createQuestions(categories, questionBlackListMap);
 

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionCreateService.java
@@ -15,10 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.wsws.moduledomain.category.vo.CategoryName.*;
 import static com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil.*;
@@ -36,6 +33,7 @@ public class ScheduledQuestionCreateService {
 
     private List<String> categories;
     private Map<String, List<String>> questionBlackList;
+    private Map<String, String> questionTempStore; // 검증이 끝난 질문 임시 저장소
 
     /**
      * 매일 23시 30분에 질문을 생성
@@ -45,7 +43,7 @@ public class ScheduledQuestionCreateService {
         initList(); // 리스트 초기화
 
         // 모든 카테고리의 질문들이 생성될 때 까지 반복
-        while(!categories.isEmpty()) {
+        while (!categories.isEmpty()) {
             Map<String, String> createdQuestions = questionGenerateClient.createQuestions(categories, questionBlackList);
 
             // 질문 검증 및 저장
@@ -54,11 +52,13 @@ public class ScheduledQuestionCreateService {
                 List<String> similarQuestions = redisVectorClient.findSimilarText(question);
 
                 if (similarQuestions.isEmpty()) { // 중복되지 않는 질문일 때,
-                    saveQuestion(categoryName, question); // 데이터베이스에 질문 저장
+                    log.info("질문 검증 완료: {}: {}", categoryName, question);
+                    questionTempStore.put(categoryName, question); // 질문 리스트에 임시 저장
+                    removeCategoryFromList(categoryName); // 저장한 질문의 카테고리는 리스트에서 제외
                 } else { // 중복된 질문이면
                     // 질문 블랙 리스트에 추가
                     log.info("질문 중복: {}: {}", categoryName, question);
-                    if(questionBlackList.containsKey(categoryName)) { // 생성된 질문 블랙리스트에 저장
+                    if (questionBlackList.containsKey(categoryName)) { // 생성된 질문 블랙리스트에 저장
                         questionBlackList.get(categoryName).add(question);
                     } else {
                         questionBlackList.put(categoryName, new ArrayList<>(List.of(question)));
@@ -67,7 +67,9 @@ public class ScheduledQuestionCreateService {
                 }
             }
         }
-        log.info("모든 질문 생성완료. 사용된 누적 토큰 수: [입력토큰: {}, 출력토큰: {}, 총합: {}", getPromptToken(), getGenerationToken(), getTotalToken());
+        log.info("모든 질문 생성완료.");
+        saveQuestion(); // 데이터베이스에 질문 저장.
+        log.info(" 사용된 누적 토큰 수: [입력토큰: {}, 출력토큰: {}, 총합: {}]", getPromptToken(), getGenerationToken(), getTotalToken());
     }
 
 
@@ -77,23 +79,31 @@ public class ScheduledQuestionCreateService {
     private void initList() {
         categories = new ArrayList<>(List.of(TRAVEL.name(), DELICIOUS_RESTAURANT.name(), MOVIE.name(), MUSIC.name(), READING.name(), SPORTS.name()));
         questionBlackList = new HashMap<>();
+        questionTempStore = new HashMap<>();
     }
 
     /**
      * 데이터베이스에 질문 저장
+     * 질문 저장은 모든 질문들의 검증이 끝난 후에 이루어진다.
+     * -> 저장해야하는 데이터베이스가 두 개이기 때문에 데이터 불일치를 방지하기 위함.
      */
-    private void saveQuestion(String categoryName, String question) {
-        redisVectorClient.store(question); // 벡터 데이터베이스에 질문 저장
-        Category category = categoryRepository.findByCategoryName(CategoryName.valueOf(categoryName));
-        questionRepository.save(Question.create(question, QuestionStatus.CREATED, LocalDateTime.now(), category.getId())); // Question 엔티티 RDBMS에 저장
+    private void saveQuestion() {
+        log.info("데이터베이스에 질문을 저장");
 
-        removeList(categoryName); // 저장한 질문의 카테고리는 리스트에서 제외
+        // 벡터 데이터베이스에 질문 저장
+        redisVectorClient.store(questionTempStore.values().stream().toList());
+
+        // RDBMS에 질문 저장
+        for (String c : questionTempStore.keySet()) {
+            Category category = categoryRepository.findByCategoryName(CategoryName.valueOf(c)); // 카테고리에 ID를 받아옴.
+            questionRepository.save(Question.create(questionTempStore.get(c), QuestionStatus.CREATED, LocalDateTime.now(), category.getId())); // Question 엔티티 RDBMS에 저장
+        }
     }
 
     /**
      * 해당 카테고리 리스트에서 제외
      */
-    private void removeList(String categoryName) {
+    private void removeCategoryFromList(String categoryName) {
         categories.remove(categoryName);
         questionBlackList.remove(categoryName);
     }

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionUpdateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionUpdateService.java
@@ -1,5 +1,6 @@
 package com.wsws.moduleapplication.feed.service.scheduler;
 
+import com.wsws.moduleapplication.feed.service.QuestionAIService;
 import com.wsws.moduledomain.feed.question.Question;
 import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
@@ -12,10 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
-@Transactional
 @Slf4j
 public class ScheduledQuestionUpdateService {
-    private final QuestionRepository questionRepository;
+    private final QuestionAIService questionAIService;
 
     /**
      * 매일 자정에 Question 테이블의 Question Status 컬럼 변경
@@ -24,14 +24,8 @@ public class ScheduledQuestionUpdateService {
      */
     @Scheduled(cron = "0 0 0 * * ?") // 매일 00시 00분에 실행되도록 설정
     public void updateQuestions() {
-        // 어제 질문들 비활성화
-        questionRepository.findByQuestionStatus(QuestionStatus.ACTIVATED)
-                .forEach(Question::inactivateQuestion);
 
-        // 오늘 질문들 활성화
-        questionRepository.findByQuestionStatus(QuestionStatus.CREATED)
-                .forEach(Question::activateQuestion);
-
+        questionAIService.updateQuestions();
         log.info("스케줄링 작업 완료");
     }
 }

--- a/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionUpdateService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/feed/service/scheduler/ScheduledQuestionUpdateService.java
@@ -1,15 +1,10 @@
 package com.wsws.moduleapplication.feed.service.scheduler;
 
 import com.wsws.moduleapplication.feed.service.QuestionAIService;
-import com.wsws.moduledomain.feed.question.Question;
-import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
-import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -24,8 +19,29 @@ public class ScheduledQuestionUpdateService {
      */
     @Scheduled(cron = "0 0 0 * * ?") // 매일 00시 00분에 실행되도록 설정
     public void updateQuestions() {
+        int maxRetries = 3; // 최대 재시도 횟수
+        int attempt = 0;    // 현재 시도 횟수
 
-        questionAIService.updateQuestions();
-        log.info("스케줄링 작업 완료");
+        while (attempt < maxRetries) {
+            try {
+                attempt++;
+                log.info("스케줄링 작업 실행, 시도 횟수: {}", attempt);
+
+                // 질문 상태 업데이트 로직
+                questionAIService.updateQuestions();
+
+                // 성공하면 루프 종료
+                log.info("스케줄링 작업 완료, 시도 횟수: {}", attempt);
+                break;
+            } catch (Exception e) {
+                log.error("스케줄링 작업 실패, 시도 횟수: {}, 에러: {}", attempt, e.getMessage());
+
+                // 마지막 시도에서 실패했을 때 추가 처리
+                if (attempt >= maxRetries) {
+                    log.error("스케줄링 작업 모든 재시도 실패. ");
+                    // TODO: 이메일로 알림
+                }
+            }
+        }
     }
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
@@ -13,4 +13,10 @@ public class Category {
 
     @Enumerated(EnumType.STRING)
     private CategoryName categoryName;
+
+    public static Category create(CategoryName categoryName) {
+        Category category = new Category();
+        category.categoryName = categoryName;
+        return category;
+    }
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
@@ -2,8 +2,10 @@ package com.wsws.moduledomain.category;
 
 import com.wsws.moduledomain.category.vo.CategoryName;
 import jakarta.persistence.*;
+import lombok.Getter;
 
 @Entity
+@Getter
 public class Category {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "category_id")

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
@@ -1,11 +1,14 @@
 package com.wsws.moduledomain.category;
 
 import com.wsws.moduledomain.category.vo.CategoryName;
-import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Category {
     private Long id;
     private CategoryName categoryName;

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/Category.java
@@ -4,14 +4,10 @@ import com.wsws.moduledomain.category.vo.CategoryName;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-@Entity
+
 @Getter
 public class Category {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "category_id")
     private Long id;
-
-    @Enumerated(EnumType.STRING)
     private CategoryName categoryName;
 
     public static Category create(CategoryName categoryName) {
@@ -20,3 +16,4 @@ public class Category {
         return category;
     }
 }
+

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
@@ -8,4 +8,9 @@ public interface CategoryRepository {
      * 카테고리 이름으로 카테고리 받아오기
      */
     Category findByCategoryName(CategoryName categoryName);
+
+    /**
+     * 카테고리 저장하기
+     */
+    Category save(Category category);
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
@@ -1,0 +1,11 @@
+package com.wsws.moduledomain.category.repo;
+
+import com.wsws.moduledomain.category.Category;
+import com.wsws.moduledomain.category.vo.CategoryName;
+
+public interface CategoryRepository {
+    /**
+     * 카테고리 이름으로 카테고리 받아오기
+     */
+    Category findByCategoryName(CategoryName categoryName);
+}

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
@@ -3,11 +3,18 @@ package com.wsws.moduledomain.category.repo;
 import com.wsws.moduledomain.category.Category;
 import com.wsws.moduledomain.category.vo.CategoryName;
 
+import java.util.List;
+
 public interface CategoryRepository {
     /**
      * 카테고리 이름으로 카테고리 받아오기
      */
     Category findByCategoryName(CategoryName categoryName);
+
+    /**
+     * 카테고리 전부 받아오기
+     */
+    List<Category> findAll();
 
     /**
      * 카테고리 저장하기

--- a/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/category/repo/CategoryRepository.java
@@ -14,7 +14,7 @@ public interface CategoryRepository {
     /**
      * 카테고리 전부 받아오기
      */
-    List<Category> findAll();
+    List<Category> findAllCategories();
 
     /**
      * 카테고리 저장하기

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
@@ -8,15 +8,16 @@ import java.time.LocalDateTime;
 
 @Getter
 public class Question {
-    private QuestionId id;
+    private QuestionId questionId;
     private String content;
     private QuestionStatus questionStatus;
     private LocalDateTime createdAt;
     private Long categoryId;
 
 
-    public static Question create(String content, QuestionStatus questionStatus, LocalDateTime createdAt, Long categoryId) {
+    public static Question create(QuestionId questionId, String content, QuestionStatus questionStatus, LocalDateTime createdAt, Long categoryId) {
         Question question = new Question();
+        question.questionId = questionId;
         question.content = content;
         question.questionStatus = questionStatus;
         question.createdAt = createdAt;

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
@@ -1,24 +1,16 @@
 package com.wsws.moduledomain.feed.question;
 
-import com.wsws.moduledomain.category.Category;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
-import jakarta.persistence.*;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
-@Entity
 @Getter
 public class Question {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "question_id")
     Long id;
-
     private String content;
-    @Enumerated(EnumType.STRING)
     private QuestionStatus questionStatus;
     private LocalDateTime createdAt;
-
     private Long categoryId;
 
 

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
@@ -1,5 +1,6 @@
 package com.wsws.moduledomain.feed.question;
 
+import com.wsws.moduledomain.feed.question.vo.QuestionId;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
 import lombok.Getter;
 
@@ -7,7 +8,7 @@ import java.time.LocalDateTime;
 
 @Getter
 public class Question {
-    Long id;
+    private QuestionId id;
     private String content;
     private QuestionStatus questionStatus;
     private LocalDateTime createdAt;

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/Question.java
@@ -15,9 +15,9 @@ public class Question {
     private Long categoryId;
 
 
-    public static Question create(QuestionId questionId, String content, QuestionStatus questionStatus, LocalDateTime createdAt, Long categoryId) {
+    public static Question create(Long questionId, String content, QuestionStatus questionStatus, LocalDateTime createdAt, Long categoryId) {
         Question question = new Question();
-        question.questionId = questionId;
+        question.questionId = QuestionId.of(questionId);
         question.content = content;
         question.questionStatus = questionStatus;
         question.createdAt = createdAt;

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/ai/QuestionGenerateClient.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/ai/QuestionGenerateClient.java
@@ -9,4 +9,11 @@ public interface QuestionGenerateClient {
      * 생성해야하는 카테고리 목록들을 받아 프롬프트를 작성해 질문 생성
      */
     Map<String, String> createQuestions(List<String> categories, Map<String, Set<String>> questionBlackListMap);
+
+    /**
+     * 토큰 계산 결과 받아오기
+     */
+    Long getPromptTokens();
+    Long getGenerationTokens();
+    Long getTotalTokens();
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/ai/QuestionGenerateClient.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/ai/QuestionGenerateClient.java
@@ -1,0 +1,12 @@
+package com.wsws.moduledomain.feed.question.ai;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public interface QuestionGenerateClient {
+    /**
+     * 생성해야하는 카테고리 목록들을 받아 프롬프트를 작성해 질문 생성
+     */
+    Map<String, String> createQuestions(List<String> categories, Map<String, Set<String>> questionBlackListMap);
+}

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/ai/VectorClient.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/ai/VectorClient.java
@@ -1,0 +1,20 @@
+package com.wsws.moduledomain.feed.question.ai;
+
+import java.util.List;
+
+public interface VectorClient {
+    /**
+     * 벡터 데이터베이스에 텍스트 하나 저장
+     */
+    void store(String text);
+
+    /**
+     * 벡터 데이터베이스에 텍스트 여러 개 저장
+     */
+    void store(List<String> texts);
+
+    /**
+     * 비슷한 텍스트를 찾아 반환
+     */
+    List<String> findSimilarText(String text);
+}

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/repo/QuestionRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/repo/QuestionRepository.java
@@ -4,6 +4,7 @@ import com.wsws.moduledomain.feed.question.Question;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestionRepository {
 
@@ -14,5 +15,5 @@ public interface QuestionRepository {
     Question save(Question question);
 
     // 카테고리를 기준으로 질문 가져오기
-    Question findByCategoryId(Long id);
+    Optional<Question> findByCategoryId(Long id);
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/repo/QuestionRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/repo/QuestionRepository.java
@@ -12,4 +12,7 @@ public interface QuestionRepository {
 
     // 질문 저장
     Question save(Question question);
+
+    // 카테고리를 기준으로 질문 가져오기
+    Question findByCategoryId(Long id);
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/repo/QuestionRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/repo/QuestionRepository.java
@@ -10,4 +10,6 @@ public interface QuestionRepository {
     // 질문 상태를 기준으로 질문 가져오기
     List<Question> findByQuestionStatus(QuestionStatus questionStatus);
 
+    // 질문 저장
+    Question save(Question question);
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/vo/QuestionId.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/vo/QuestionId.java
@@ -1,0 +1,24 @@
+package com.wsws.moduledomain.feed.question.vo;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Getter
+@EqualsAndHashCode
+@NoArgsConstructor
+public class QuestionId implements Serializable {
+
+    private Long id;
+
+    private QuestionId(Long id) {
+        this.id = id;
+    }
+
+    public static QuestionId of(Long id) {
+        return new QuestionId(id);
+    }
+}

--- a/module-domain/src/main/java/com/wsws/moduledomain/feed/question/vo/QuestionId.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/feed/question/vo/QuestionId.java
@@ -5,17 +5,16 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.io.Serializable;
-import java.util.UUID;
 
 @Getter
 @EqualsAndHashCode
 @NoArgsConstructor
 public class QuestionId implements Serializable {
 
-    private Long id;
+    private Long value;
 
-    private QuestionId(Long id) {
-        this.id = id;
+    private QuestionId(Long value) {
+        this.value = value;
     }
 
     public static QuestionId of(Long id) {

--- a/module-external-api/build.gradle
+++ b/module-external-api/build.gradle
@@ -1,5 +1,7 @@
 dependencies {
     implementation project(':module-common')
+    implementation project(':module-domain')
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
     implementation 'org.springframework.ai:spring-ai-redis-store-spring-boot-starter'

--- a/module-external-api/build.gradle
+++ b/module-external-api/build.gradle
@@ -1,15 +1,8 @@
-ext {
-    springAiVersion = "1.0.0-M4"
-}
-
-dependencyManagement {
-    imports {
-        mavenBom "org.springframework.ai:spring-ai-bom:$springAiVersion"
-    }
-}
 dependencies {
     implementation project(':module-common')
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.ai:spring-ai-openai-spring-boot-starter'
+    implementation 'org.springframework.ai:spring-ai-redis-store-spring-boot-starter'
+    implementation 'redis.clients:jedis:5.1.0'
 
 }

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClient.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClient.java
@@ -1,6 +1,11 @@
 package com.wsws.moduleexternalapi.feed.client;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.messages.Message;
 import org.springframework.ai.chat.model.ChatModel;
 import org.springframework.ai.chat.model.ChatResponse;
@@ -10,53 +15,96 @@ import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.chat.prompt.SystemPromptTemplate;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
+@Slf4j
 public class QuestionGenerateClient {
     private final ChatModel chatModel;
     private final ChatOptions chatOptions;
 
+    private static int TOTAL_TOKEN_COUNT = 0;
+
+    // 시스템 프롬프트
     private static final String SYSTEM_PROMPT = """ 
             You are an expert assistant that creates engaging and relevant content for the MZ generation in their 20s and 30s in Korea. Your task is to provide natural and appealing responses.
             """;
+
+    // 유저 프롬프트
     private static final String USER_PROMPT = """ 
             Your task is to create one engaging and relevant question for each of the {categoriesSize} categories: {categories}
             The target audience is the MZ generation in their 20s and 30s in Korea. 
             Provide the questions in Korean and ensure the response is a 'pure JSON object without any Markdown formatting(do not include ```json)'. Ensure the questions are natural and appealing.
             """;
 
+    //  제외시킬 질문들에 대한 프롬프트
+    private static final String QUESTION_BLACKLIST_PROMPT = """
+            Generate a "completely" different question from the following content.
+            {questionBlackList}
+            Ensure that the new question has no semantic, structural, or thematic similarity to the above questions. Avoid rephrasing or minor changes.
+            """;
+
+
     /**
      * 생성해야하는 카테고리 목록들을 받아 프롬프트를 작성해 질문 생성
      */
-    public Map<String, String> createQuestions(List<String> categories) {
-        Prompt prompt = createPrompt(categories);
-        System.out.println(prompt);
+    public Map<String, String> createQuestions(List<String> categories, Map<String, List<String>> questionBlackList) {
+        log.info("질문 생성 시도");
+        log.info("질문 블랙리스트: {}", questionBlackList);
+        Prompt prompt = createPrompt(categories, questionBlackList);
         ChatResponse response = chatModel.call(prompt);
-        System.out.println(response);
-        String content = response.getResult().getOutput().getContent();
-        System.out.println(content);
-        return null;
+
+        calculateTokens(response);
+
+        String content = response.getResult().getOutput().getContent(); // json 형태의 질문들
+        log.info("질문 생성 완료: {}", content);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            JsonNode questionsNode = objectMapper.readTree(content); // 문자열 형태의 Json을 JsonNode로 파싱
+            Map<String, String> questionMap = new HashMap<>();
+            categories.forEach(category -> questionMap.put(category, questionsNode.get(category).asText())); // 뽑아낸 질문들을 Map에 저장
+            return questionMap;
+        } catch (JsonProcessingException e) {
+            return Map.of(); // Json Parsing 오류시 빈 Map 반환
+        }
+    }
+
+    private void calculateTokens(ChatResponse response) {
+        TokenCalculateUtil.addPromptToken(response.getMetadata().getUsage().getPromptTokens()); // 사용된 입력 토큰 계산
+        TokenCalculateUtil.addGenerationToken(response.getMetadata().getUsage().getGenerationTokens()); // 사용된 출력 토큰 계산
+        TokenCalculateUtil.addTotalToken(response.getMetadata().getUsage().getTotalTokens()); // 사용된 누적 토큰 계산
     }
 
 
     /**
-     *
-     * @param categories
-     * @return
+     * 프롬프트 생성
      */
-    private Prompt createPrompt(List<String> categories) {
+    private Prompt createPrompt(List<String> categories, Map<String, List<String>> questionBlackList) {
+
+        List<Message> promptMessageList = new ArrayList<>();
 
         // 시스템 프롬프트 생성
         SystemPromptTemplate systemPromptTemplate = new SystemPromptTemplate(SYSTEM_PROMPT);
         Message systemMessage = systemPromptTemplate.createMessage();
+        promptMessageList.add(systemMessage);
 
         // 사용자 프롬프트 생성
         PromptTemplate userPromptTemplate = new PromptTemplate(USER_PROMPT);
         Message userMessage = userPromptTemplate.createMessage(Map.of("categoriesSize", categories.size(), "categories", categories.toString()));
+        promptMessageList.add(userMessage);
 
-        return new Prompt(List.of(systemMessage, userMessage), chatOptions);
+        // 질문 블랙리스트 프롬프트 생성
+        if(!questionBlackList.isEmpty()) {
+            PromptTemplate questionBlackListPromptTemplate = new PromptTemplate(QUESTION_BLACKLIST_PROMPT);
+            Message questionBlackListMessage = questionBlackListPromptTemplate.createMessage(Map.of("questionBlackList", questionBlackList.toString()));
+            promptMessageList.add(questionBlackListMessage);
+        }
+
+        return new Prompt(promptMessageList, chatOptions);
     }
 }

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClient.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClient.java
@@ -1,4 +1,4 @@
-package com.wsws.moduleexternalapi.ai.client;
+package com.wsws.moduleexternalapi.feed.client;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.chat.messages.Message;
@@ -15,7 +15,7 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 @Component
-public class AIQuestionClient {
+public class QuestionGenerateClient {
     private final ChatModel chatModel;
     private final ChatOptions chatOptions;
 

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClient.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClient.java
@@ -15,10 +15,7 @@ import org.springframework.ai.chat.prompt.PromptTemplate;
 import org.springframework.ai.chat.prompt.SystemPromptTemplate;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 @RequiredArgsConstructor
 @Component
@@ -52,10 +49,10 @@ public class QuestionGenerateClient {
     /**
      * 생성해야하는 카테고리 목록들을 받아 프롬프트를 작성해 질문 생성
      */
-    public Map<String, String> createQuestions(List<String> categories, Map<String, List<String>> questionBlackList) {
+    public Map<String, String> createQuestions(List<String> categories, Map<String, Set<String>> questionBlackListMap) {
         log.info("질문 생성 시도");
-        log.info("질문 블랙리스트: {}", questionBlackList);
-        Prompt prompt = createPrompt(categories, questionBlackList);
+        log.info("질문 블랙리스트: {}", questionBlackListMap);
+        Prompt prompt = createPrompt(categories, questionBlackListMap);
         ChatResponse response = chatModel.call(prompt);
 
         calculateTokens(response);
@@ -84,7 +81,7 @@ public class QuestionGenerateClient {
     /**
      * 프롬프트 생성
      */
-    private Prompt createPrompt(List<String> categories, Map<String, List<String>> questionBlackList) {
+    private Prompt createPrompt(List<String> categories, Map<String, Set<String>> questionBlackList) {
 
         List<Message> promptMessageList = new ArrayList<>();
 

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClientImpl.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClientImpl.java
@@ -70,6 +70,33 @@ public class QuestionGenerateClientImpl implements QuestionGenerateClient {
         }
     }
 
+    /**
+     * 누적 입력 토큰
+     */
+    @Override
+    public Long getPromptTokens() {
+        return TokenCalculateUtil.getPromptToken();
+    }
+
+    /**
+     * 누적 출력 토큰
+     */
+    @Override
+    public Long getGenerationTokens() {
+        return TokenCalculateUtil.getGenerationToken();
+    }
+
+    /**
+     * 누적 총합 토큰
+     */
+    @Override
+    public Long getTotalTokens() {
+        return TokenCalculateUtil.getTotalToken();
+    }
+
+    /**
+     * 토큰 누적 시키기
+     */
     private void calculateTokens(ChatResponse response) {
         TokenCalculateUtil.addPromptToken(response.getMetadata().getUsage().getPromptTokens()); // 사용된 입력 토큰 계산
         TokenCalculateUtil.addGenerationToken(response.getMetadata().getUsage().getGenerationTokens()); // 사용된 출력 토큰 계산

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClientImpl.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/QuestionGenerateClientImpl.java
@@ -3,6 +3,7 @@ package com.wsws.moduleexternalapi.feed.client;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wsws.moduledomain.feed.question.ai.QuestionGenerateClient;
 import com.wsws.moduleexternalapi.feed.util.TokenCalculateUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -20,11 +21,9 @@ import java.util.*;
 @RequiredArgsConstructor
 @Component
 @Slf4j
-public class QuestionGenerateClient {
+public class QuestionGenerateClientImpl implements QuestionGenerateClient {
     private final ChatModel chatModel;
     private final ChatOptions chatOptions;
-
-    private static int TOTAL_TOKEN_COUNT = 0;
 
     // 시스템 프롬프트
     private static final String SYSTEM_PROMPT = """ 
@@ -55,7 +54,7 @@ public class QuestionGenerateClient {
         Prompt prompt = createPrompt(categories, questionBlackListMap);
         ChatResponse response = chatModel.call(prompt);
 
-        calculateTokens(response);
+        calculateTokens(response); // 사용된 토큰 계산하기
 
         String content = response.getResult().getOutput().getContent(); // json 형태의 질문들
         log.info("질문 생성 완료: {}", content);

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/RedisVectorClient.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/RedisVectorClient.java
@@ -1,0 +1,44 @@
+package com.wsws.moduleexternalapi.feed.client;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.document.Document;
+import org.springframework.ai.vectorstore.SearchRequest;
+import org.springframework.ai.vectorstore.VectorStore;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class RedisVectorClient {
+    private final VectorStore vectorStore;
+
+    /**
+     * 벡터 데이터베이스에 텍스트 하나 저장
+     */
+    public void store(String text) {
+        vectorStore.add(List.of(new Document(text)));
+    }
+
+    /**
+     * 벡터 데이터베이스에 텍스트 여러 개 저장
+     */
+    public void store(List<String> texts) {
+        vectorStore.add(texts.stream().map(Document::new).collect(Collectors.toList()));
+    }
+
+    /**
+     * 비슷한 텍스트가 있는지
+     */
+    public boolean isSimilarTextExist(String text) {
+        // 유사도가 0.8이상인 텍스트를 하나만 검색
+        List<Document> documents = vectorStore.similaritySearch(
+                SearchRequest.query(text)
+                        .withSimilarityThreshold(0.8)
+                        .withTopK(1)
+        );
+
+        return !documents.isEmpty();
+    }
+}

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/RedisVectorClient.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/RedisVectorClient.java
@@ -29,16 +29,18 @@ public class RedisVectorClient {
     }
 
     /**
-     * 비슷한 텍스트가 있는지
+     * 비슷한 텍스트를 찾아 반환
      */
-    public boolean isSimilarTextExist(String text) {
-        // 유사도가 0.8이상인 텍스트를 하나만 검색
+    public List<String> findSimilarText(String text) {
+        // 유사도가 0.8이상인 텍스트를 모두 검색
         List<Document> documents = vectorStore.similaritySearch(
                 SearchRequest.query(text)
                         .withSimilarityThreshold(0.8)
-                        .withTopK(1)
+                        .withTopK(10000) // 최댓값 10000
         );
 
-        return !documents.isEmpty();
+        return documents.stream()
+                .map(Document::getContent)
+                .collect(Collectors.toList());
     }
 }

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/VectorClientImpl.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/client/VectorClientImpl.java
@@ -1,5 +1,6 @@
 package com.wsws.moduleexternalapi.feed.client;
 
+import com.wsws.moduledomain.feed.question.ai.VectorClient;
 import lombok.RequiredArgsConstructor;
 import org.springframework.ai.document.Document;
 import org.springframework.ai.vectorstore.SearchRequest;
@@ -11,7 +12,7 @@ import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
-public class RedisVectorClient {
+public class VectorClientImpl implements VectorClient {
     private final VectorStore vectorStore;
 
     /**

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/config/ChatOptionsConfig.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/config/ChatOptionsConfig.java
@@ -1,7 +1,6 @@
-package com.wsws.moduleexternalapi.ai.config;
+package com.wsws.moduleexternalapi.feed.config;
 
-import com.wsws.moduleexternalapi.ai.client.AIQuestionClient;
-import com.wsws.moduleexternalapi.ai.dto.AIQuestionResponse;
+import com.wsws.moduleexternalapi.feed.dto.AIQuestionResponse;
 import org.springframework.ai.chat.prompt.ChatOptions;
 import org.springframework.ai.converter.BeanOutputConverter;
 import org.springframework.ai.openai.OpenAiChatOptions;

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/config/RedisVectorStoreConfig.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/config/RedisVectorStoreConfig.java
@@ -1,0 +1,45 @@
+package com.wsws.moduleexternalapi.feed.config;
+
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.ai.embedding.EmbeddingModel;
+import org.springframework.ai.vectorstore.RedisVectorStore;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import redis.clients.jedis.JedisPooled;
+
+@Configuration
+@RequiredArgsConstructor
+public class RedisVectorStoreConfig {
+
+    @Value("${spring.ai.vectorstore.redis.uri}")
+    private String redisHost;
+
+    @Value("${spring.ai.vectorstore.redis.port}")
+    private int redisPort;
+
+    @Value("${spring.ai.vectorstore.redis.index}")
+    private String redisIndex;
+
+    @Value("${spring.ai.vectorstore.redis.prefix}")
+    private String redisPredix;
+
+
+
+    @Bean
+    public JedisPooled jedisPooled() {
+        // Redis 서버의 호스트와 포트를 실제 환경에 맞게 설정하세요.
+        return new JedisPooled(redisHost, redisPort);
+    }
+
+    @Bean
+    public RedisVectorStore redisVectorStore(JedisPooled jedisPooled, EmbeddingModel embeddingModel) {
+        RedisVectorStore.RedisVectorStoreConfig config = RedisVectorStore.RedisVectorStoreConfig.builder()
+                .withIndexName(redisIndex)
+                .withPrefix(redisPredix)
+                .build();
+
+        return new RedisVectorStore(config, embeddingModel, jedisPooled, true);
+    }
+}

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/config/RedisVectorStoreConfig.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/config/RedisVectorStoreConfig.java
@@ -29,7 +29,6 @@ public class RedisVectorStoreConfig {
 
     @Bean
     public JedisPooled jedisPooled() {
-        // Redis 서버의 호스트와 포트를 실제 환경에 맞게 설정하세요.
         return new JedisPooled(redisHost, redisPort);
     }
 

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/dto/AIQuestionResponse.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/dto/AIQuestionResponse.java
@@ -2,11 +2,11 @@ package com.wsws.moduleexternalapi.feed.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 public record AIQuestionResponse(
-        @JsonProperty(required = true, value = "travel") String travel,
-        @JsonProperty(required = true, value = "deliciousRestaurant") String deliciousRestaurant,
-        @JsonProperty(required = true, value = "movie") String movie,
-        @JsonProperty(required = true, value = "music") String music,
-        @JsonProperty(required = true, value = "reading") String reading,
-        @JsonProperty(required = true, value = "sports") String sports) {
+        @JsonProperty(required = true, value = "TRAVEL") String travel,
+        @JsonProperty(required = true, value = "DELICIOUS_RESTAURANT") String deliciousRestaurant,
+        @JsonProperty(required = true, value = "MOVIE") String movie,
+        @JsonProperty(required = true, value = "MUSIC") String music,
+        @JsonProperty(required = true, value = "READING") String reading,
+        @JsonProperty(required = true, value = "SPORTS") String sports) {
 }
 

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/dto/AIQuestionResponse.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/dto/AIQuestionResponse.java
@@ -1,4 +1,4 @@
-package com.wsws.moduleexternalapi.ai.dto;
+package com.wsws.moduleexternalapi.feed.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 public record AIQuestionResponse(

--- a/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/util/TokenCalculateUtil.java
+++ b/module-external-api/src/main/java/com/wsws/moduleexternalapi/feed/util/TokenCalculateUtil.java
@@ -1,0 +1,31 @@
+package com.wsws.moduleexternalapi.feed.util;
+
+public class TokenCalculateUtil {
+    private static Long PROMPT_TOKEN_COUNT = 0L;
+    private static Long GENERATION_TOKEN_COUNT = 0L;
+    private static Long TOTAL_TOKEN_COUNT = 0L;
+
+    public static void addPromptToken(Long promptToken) {
+        PROMPT_TOKEN_COUNT += promptToken;
+    }
+
+    public static Long getPromptToken(){
+        return PROMPT_TOKEN_COUNT;
+    }
+
+    public static void addGenerationToken(Long generationToken) {
+        GENERATION_TOKEN_COUNT += generationToken;
+    }
+
+    public static Long getGenerationToken(){
+        return GENERATION_TOKEN_COUNT;
+    }
+
+    public static void addTotalToken(Long totalToken) {
+        TOTAL_TOKEN_COUNT += totalToken;
+    }
+
+    public static Long getTotalToken(){
+        return TOTAL_TOKEN_COUNT;
+    }
+}

--- a/module-external-api/src/main/resources/application-external-api.yml
+++ b/module-external-api/src/main/resources/application-external-api.yml
@@ -3,6 +3,8 @@ spring:
     name: module-external-api
 
   ai:
+    retry:
+      on-client-errors: true
     openai:
       api-key: ${OPENAI_API_KEY}
       chat:

--- a/module-external-api/src/main/resources/application-external-api.yml
+++ b/module-external-api/src/main/resources/application-external-api.yml
@@ -9,3 +9,13 @@ spring:
         options:
           model: gpt-4o-mini
           temperature: 0.9
+      embedding:
+        options:
+          model: text-embedding-3-large
+    vectorstore:
+      redis:
+        uri: ${REDIS_VECTOR_URI}
+        port: ${REDIS_VECTOR_PORT}
+        index: qfeedV-index
+        prefix: qfeedV
+        initialize-schema: true

--- a/module-infra/src/main/java/com/wsws/moduleinfra/config/JpaConfig.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/config/JpaConfig.java
@@ -11,7 +11,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @Configuration
 @EnableJpaRepositories(basePackages = "com.wsws.moduleinfra.repo") // infra 모듈의 JPA Repository 경로
-@EntityScan(basePackages = "com.wsws.moduledomain")
+@EntityScan(basePackages = "com.wsws.moduleinfra.entity")
 public class JpaConfig {
     @PersistenceContext
     private EntityManager entityManager;

--- a/module-infra/src/main/java/com/wsws/moduleinfra/entity/CategoryEntity.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/entity/CategoryEntity.java
@@ -1,0 +1,22 @@
+package com.wsws.moduleinfra.entity;
+
+import com.wsws.moduledomain.category.vo.CategoryName;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+@Entity
+@Getter
+public class CategoryEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "category_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private CategoryName categoryName;
+
+    public static CategoryEntity create(CategoryName categoryName) {
+        CategoryEntity categoryEntity = new CategoryEntity();
+        categoryEntity.categoryName = categoryName;
+        return categoryEntity;
+    }
+}

--- a/module-infra/src/main/java/com/wsws/moduleinfra/entity/QuestionEntity.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/entity/QuestionEntity.java
@@ -1,0 +1,33 @@
+package com.wsws.moduleinfra.entity;
+
+import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
+import jakarta.persistence.*;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+public class QuestionEntity {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "question_id")
+    Long id;
+
+    private String content;
+    @Enumerated(EnumType.STRING)
+    private QuestionStatus questionStatus;
+    private LocalDateTime createdAt;
+
+    private Long categoryId;
+
+
+    public static QuestionEntity create(String content, QuestionStatus questionStatus, LocalDateTime createdAt, Long categoryId) {
+        QuestionEntity questionEntity = new QuestionEntity();
+        questionEntity.content = content;
+        questionEntity.questionStatus = questionStatus;
+        questionEntity.createdAt = createdAt;
+        questionEntity.categoryId = categoryId;
+        return questionEntity;
+    }
+
+}

--- a/module-infra/src/main/java/com/wsws/moduleinfra/entity/feed/QuestionEntity.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/entity/feed/QuestionEntity.java
@@ -1,4 +1,4 @@
-package com.wsws.moduleinfra.entity;
+package com.wsws.moduleinfra.entity.feed;
 
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
 import jakarta.persistence.*;

--- a/module-infra/src/main/java/com/wsws/moduleinfra/entity/feed/QuestionEntity.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/entity/feed/QuestionEntity.java
@@ -1,5 +1,7 @@
 package com.wsws.moduleinfra.entity.feed;
 
+import com.wsws.moduledomain.feed.question.Question;
+import com.wsws.moduledomain.feed.question.vo.QuestionId;
 import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
 import jakarta.persistence.*;
 import lombok.Getter;

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/category/CategoryJpaRepository.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/category/CategoryJpaRepository.java
@@ -1,0 +1,18 @@
+package com.wsws.moduleinfra.repo.category;
+
+import com.wsws.moduledomain.category.Category;
+import com.wsws.moduledomain.category.repo.CategoryRepository;
+import com.wsws.moduleinfra.entity.CategoryEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryJpaRepository extends JpaRepository<CategoryEntity, Long>, CategoryRepository {
+
+    @Override
+    @Query("select new com.wsws.moduledomain.category.Category(c.id, c.categoryName) from CategoryEntity c")
+    List<Category> findAllCategories();
+}

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionJpaRepository.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionJpaRepository.java
@@ -1,11 +1,11 @@
 package com.wsws.moduleinfra.repo.feed;
 
-import com.wsws.moduledomain.feed.question.Question;
 import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
+import com.wsws.moduleinfra.entity.QuestionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface QuestionJpaRepository extends JpaRepository<Question, Long>, QuestionRepository{
+public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Long>, QuestionRepository{
 
 }

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionJpaRepository.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionJpaRepository.java
@@ -1,11 +1,15 @@
 package com.wsws.moduleinfra.repo.feed;
 
+import com.wsws.moduledomain.feed.question.Question;
 import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
+import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
 import com.wsws.moduleinfra.entity.feed.QuestionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-@Repository
-public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Long>, QuestionRepository{
+import java.util.List;
 
+@Repository
+public interface QuestionJpaRepository extends JpaRepository<QuestionEntity, Long>{
+    List<QuestionEntity> findByQuestionStatus(QuestionStatus questionStatus);
 }

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionJpaRepository.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionJpaRepository.java
@@ -1,7 +1,7 @@
 package com.wsws.moduleinfra.repo.feed;
 
 import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
-import com.wsws.moduleinfra.entity.QuestionEntity;
+import com.wsws.moduleinfra.entity.feed.QuestionEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionRepositoryImpl.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/QuestionRepositoryImpl.java
@@ -1,0 +1,41 @@
+package com.wsws.moduleinfra.repo.feed;
+
+import com.wsws.moduledomain.feed.question.Question;
+import com.wsws.moduledomain.feed.question.repo.QuestionRepository;
+import com.wsws.moduledomain.feed.question.vo.QuestionStatus;
+import com.wsws.moduleinfra.entity.feed.QuestionEntity;
+import com.wsws.moduleinfra.repo.feed.mapper.QuestionMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QuestionRepositoryImpl implements QuestionRepository {
+
+    private final QuestionJpaRepository questionJpaRepository;
+
+    @Override
+    public List<Question> findByQuestionStatus(QuestionStatus questionStatus) {
+        // QuestionEntity 리스트를 가져옴
+        List<QuestionEntity> entities = questionJpaRepository.findByQuestionStatus(questionStatus);
+
+        return entities.stream()
+                .map(QuestionMapper::toDomain) // toDomain 메서드로 변환
+                .toList(); // 최종적으로 리스트 반환
+    }
+
+    @Override
+    public Question save(Question question) {
+        QuestionEntity questionEntity = questionJpaRepository.save(QuestionMapper.toEntity(question));
+        return QuestionMapper.toDomain(questionEntity);
+    }
+
+    @Override
+    public Optional<Question> findByCategoryId(Long id) {
+        return questionJpaRepository.findById(id)
+                .map(QuestionMapper::toDomain); // 값이 있으면 변환하고, 없으면 빈 Optional 반환
+    }
+}

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/mapper/QuestionMapper.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/mapper/QuestionMapper.java
@@ -1,0 +1,26 @@
+package com.wsws.moduleinfra.repo.feed.mapper;
+
+import com.wsws.moduledomain.feed.question.Question;
+import com.wsws.moduledomain.feed.question.vo.QuestionId;
+import com.wsws.moduleinfra.entity.feed.QuestionEntity;
+
+public class QuestionMapper {
+    public static Question toDomain(QuestionEntity entity) {
+        return Question.create(
+                QuestionId.of(entity.getId()),
+                entity.getContent(),
+                entity.getQuestionStatus(),
+                entity.getCreatedAt(),
+                entity.getCategoryId()
+        );
+    }
+
+    public static QuestionEntity toEntity(Question question) {
+        return QuestionEntity.create(
+                question.getContent(),
+                question.getQuestionStatus(),
+                question.getCreatedAt(),
+                question.getCategoryId()
+        );
+    }
+}

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/mapper/QuestionMapper.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/feed/mapper/QuestionMapper.java
@@ -7,7 +7,7 @@ import com.wsws.moduleinfra.entity.feed.QuestionEntity;
 public class QuestionMapper {
     public static Question toDomain(QuestionEntity entity) {
         return Question.create(
-                QuestionId.of(entity.getId()),
+                entity.getId(),
                 entity.getContent(),
                 entity.getQuestionStatus(),
                 entity.getCreatedAt(),

--- a/module-infra/src/main/resources/application-infra.yml
+++ b/module-infra/src/main/resources/application-infra.yml
@@ -6,7 +6,7 @@ spring:
     driver-class-name: ${DATABASE_DRIVER}
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
   mail:
     host: smtp.gmail.com          # SMTP 서버 호스트
     port: 587                     # SMTP 포트 (TLS)

--- a/module-infra/src/main/resources/application-infra.yml
+++ b/module-infra/src/main/resources/application-infra.yml
@@ -21,3 +21,7 @@ spring:
 redis:
   host: ${REDIS_HOST}
   port: ${REDIS_PORT}
+
+logging.level:
+  org.hibernate.SQL: debug
+  org.hibernate.orm.jdbc.bind: trace


### PR DESCRIPTION
<!--
  템플릿은 아직 PR 작성이 익숙하지 않으신 분들을 위해서 제공하는 가이드입니다!
  리뷰어 또는 이 PR을 보게 될 다른 사람들이 이 PR을 보는데 참고할 수 있는 내용이 있다면 포함해서 작성해주시면 됩니다.
-->
#10 피드백 반영 및 의존성 리팩토링


## ✅ 피드백 반영사항  <!-- 지난 코드리뷰에서 고친 사항을 적어주세요. 재PR 시에만 사용해 주세요! (재PR 아닌 경우 삭제) -->
1. ScheduledQuestionCreateService와 ScheduledQuestionUpdateService에서 데이터 접근 로직을 QuestionAIService 클래스로 분리하여 내부에서 @Transactional 적용
2.  QuestionAIService에서 AI 관련 모든 로직을 실행하도록 책임 분리
3. ScheduledQuestionCreateService에서 멀티스레드 환경에서도 작동하는 자료구조로 변경
4. Map관련 로직을 if-else로 구현하는 것이 아닌 computeIfAbasent()로 리팩토링
5. 스케줄링 시 재시도 로직 추가 및 재시도 제한 횟수 설정

**의존성 리팩토링 관련**
7. Domain 중심으로 코드 리팩토링
     - a) Application->External-api를 의존성 제거
     - b) External api -> Domain 의존성 추가
     - c) Domain에 External-api 관련 인터페이스 추가
     - d) Question Domain @Entity를 Infra 계층으로 이동. 비즈니스 로직과 VO는 Domain 계층에 위치
     - e) Repository 인터페이스에는 Domain, 구현체에는 Entity, 혹은 필요시 Domain 의존
8. Question 도메인의 Long id를 QuestionId로 감쌈 
9. Infra의 Repository를 QuestionJpaRepository, QuestionRepositoryImpl로 분리
10. QuestionMapper 클래스를 통해 도메인 <-> 엔티티 변환 책임 분리
 
## ✅ PR 포인트 & 궁금한 점 <!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
