### PR TITLE
Refactor/QFEED-123-query-opt-cache

### DIFF
--- a/module-api/src/main/java/com/wsws/moduleapi/user/controller/UserController.java
+++ b/module-api/src/main/java/com/wsws/moduleapi/user/controller/UserController.java
@@ -1,11 +1,7 @@
 package com.wsws.moduleapi.user.controller;
 
 import com.wsws.moduleapi.auth.dto.AuthResponse;
-import com.wsws.moduleapi.user.dto.UserProfileApiResponse;
-import com.wsws.moduleapplication.user.dto.PasswordChangeServiceDto;
-import com.wsws.moduleapplication.user.dto.RegisterUserRequest;
-import com.wsws.moduleapplication.user.dto.UpdateFcmTokenRequest;
-import com.wsws.moduleapplication.user.dto.UpdateProfileServiceDto;
+import com.wsws.moduleapplication.user.dto.*;
 import com.wsws.moduleapplication.user.service.UserQueryService;
 import com.wsws.moduleapplication.user.service.UserService;
 import com.wsws.modulesecurity.security.UserPrincipal;
@@ -45,9 +41,9 @@ public class UserController {
             @ApiResponse(responseCode = "404", description = "사용자를 찾을 수 없음", content = @Content)
     })
     @GetMapping("/{userId}")
-    public ResponseEntity<UserProfileApiResponse> getUser(
+    public ResponseEntity<FullUserProfileResponse> getUser(
             @Parameter(description = "검색할 사용자의 ID") @PathVariable String userId) {
-        UserProfileApiResponse response = new UserProfileApiResponse(userQueryService.getUserProfile(userId));
+        FullUserProfileResponse response = userQueryService.getFullUserProfile(userId);
         return ResponseEntity.ok(response);
     }
 

--- a/module-api/src/main/java/com/wsws/moduleapi/user/dto/UserProfileApiResponse.java
+++ b/module-api/src/main/java/com/wsws/moduleapi/user/dto/UserProfileApiResponse.java
@@ -12,15 +12,15 @@ public record UserProfileApiResponse(
         int followingCount
 ) {
 
-    public UserProfileApiResponse(UserProfileResponse serviceResponse) {
+    public UserProfileApiResponse(UserProfileResponse serviceResponse, int followerCount, int followingCount) {
         this(
                 serviceResponse.userId(),
                 serviceResponse.email(),
                 serviceResponse.nickname(),
                 serviceResponse.profileImage(),
                 serviceResponse.description(),
-                serviceResponse.followerCount(),
-                serviceResponse.followingCount()
+                followerCount,
+                followingCount
         );
     }
 }

--- a/module-application/src/main/java/com/wsws/moduleapplication/follow/service/FollowService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/follow/service/FollowService.java
@@ -14,7 +14,7 @@ import com.wsws.moduledomain.user.vo.UserId;
 import com.wsws.moduleexternalapi.fcm.dto.fcmRequestDto;
 import com.wsws.moduleexternalapi.fcm.service.FcmService;
 import com.wsws.moduleexternalapi.fcm.util.FcmType;
-import com.wsws.moduleinfra.cache.CacheManager;
+import com.wsws.moduledomain.cache.CacheManager;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/dto/FullUserProfileResponse.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/dto/FullUserProfileResponse.java
@@ -1,0 +1,23 @@
+package com.wsws.moduleapplication.user.dto;
+
+public record FullUserProfileResponse(
+        String userId,
+        String nickname,
+        String email,
+        String profileImageUrl,
+        String description,
+        long followerCount,
+        long followingCount
+) {
+    public FullUserProfileResponse(UserProfileResponse profile, long followerCount, long followingCount) {
+        this(
+                profile.userId(),
+                profile.nickname(),
+                profile.email(),
+                profile.profileImage(),
+                profile.description(),
+                followerCount,
+                followingCount
+        );
+    }
+}

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/dto/UserProfileResponse.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/dto/UserProfileResponse.java
@@ -7,19 +7,16 @@ public record UserProfileResponse(
         String email,
         String nickname,
         String profileImage,
-        String description,
-        int followerCount,
-        int followingCount
+        String description
+
 ) {
-    public UserProfileResponse(User user, int followerCount, int followingCount) {
+    public UserProfileResponse(User user) {
         this(
                 user.getId().getValue(),
                 user.getEmail().getValue(),
                 user.getNickname().getValue(),
                 user.getProfileImage(),
-                user.getDescription(),
-                followerCount,
-                followingCount
+                user.getDescription()
         );
     }
 }

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/dto/UserRecommendationMapper.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/dto/UserRecommendationMapper.java
@@ -1,7 +1,7 @@
 package com.wsws.moduleapplication.user.dto;
 
 
-import com.wsws.moduledomain.recommendation.UserRecommendation;
+import com.wsws.moduledomain.follow.vo.UserRecommendation;
 
 import java.util.List;
 

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/service/RecommendationService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/service/RecommendationService.java
@@ -2,6 +2,7 @@ package com.wsws.moduleapplication.user.service;
 
 import com.wsws.moduleapplication.user.dto.UserRecommendationMapper;
 import com.wsws.moduleapplication.user.dto.UserRecommendationResponse;
+import com.wsws.moduledomain.recommendation.UserRecommendation;
 import com.wsws.moduledomain.recommendation.repo.UserRecommendationRepository;
 import com.wsws.moduledomain.user.repo.UserInterestRepository;
 import com.wsws.moduledomain.user.vo.UserId;
@@ -19,8 +20,23 @@ public class RecommendationService {
     private final UserInterestRepository userInterestRepository;
 
     public List<UserRecommendationResponse> getRecommendations(String userId, int limit) {
+        // 사용자 관심사 조회
+        List<Long> interestCategoryIds = userInterestRepository.findByUserId(UserId.of(userId))
+                .stream()
+                .map(interest -> interest.getCategoryId().getValue())
+                .toList();
 
-        List<UserInterest> userInterests = userInterestRepository.findByUserId(UserId.of(userId));
-        return UserRecommendationMapper.toDtoList(userRecommendationRepository.findTopRecommendations(userId, userInterests, limit)) ;
+        // 관심사 기반 추천 조회
+        List<UserRecommendation> commonInterestUsers = userRecommendationRepository.findTopRecommendations(userId, interestCategoryIds, limit);
+
+        // 부족한 수 일반 사용자로 채우기
+        int remaining = limit - commonInterestUsers.size();
+        if (remaining > 0) {
+            List<UserRecommendation> generalUsers = userRecommendationRepository.findGeneralRecommendations(userId, remaining);
+            commonInterestUsers.addAll(generalUsers);
+        }
+
+        // DTO로 변환
+        return UserRecommendationMapper.toDtoList(commonInterestUsers);
     }
 }

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/service/RecommendationService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/service/RecommendationService.java
@@ -2,11 +2,10 @@ package com.wsws.moduleapplication.user.service;
 
 import com.wsws.moduleapplication.user.dto.UserRecommendationMapper;
 import com.wsws.moduleapplication.user.dto.UserRecommendationResponse;
-import com.wsws.moduledomain.recommendation.UserRecommendation;
-import com.wsws.moduledomain.recommendation.repo.UserRecommendationRepository;
+import com.wsws.moduledomain.follow.vo.UserRecommendation;
+import com.wsws.moduledomain.follow.UserRecommendationRepository;
 import com.wsws.moduledomain.user.repo.UserInterestRepository;
 import com.wsws.moduledomain.user.vo.UserId;
-import com.wsws.moduledomain.user.vo.UserInterest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +35,7 @@ public class RecommendationService {
             commonInterestUsers.addAll(generalUsers);
         }
 
-        // DTO로 변환
+
         return UserRecommendationMapper.toDtoList(commonInterestUsers);
     }
 }

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/service/UserQueryService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/service/UserQueryService.java
@@ -1,5 +1,6 @@
 package com.wsws.moduleapplication.user.service;
 
+import com.wsws.moduleapplication.user.dto.FullUserProfileResponse;
 import com.wsws.moduleapplication.user.dto.UserProfileResponse;
 import com.wsws.moduleapplication.user.exception.UserNotFoundException;
 import com.wsws.moduleinfra.cache.CacheManager;
@@ -19,26 +20,62 @@ public class UserQueryService {
     private final FollowReadRepository followReadRepository;
     private final CacheManager cacheManager;
 
+    // UserProfile 캐싱 처리
     public UserProfileResponse getUserProfile(String userId) {
+        String profileCacheKey = "user:" + userId + ":profile";
 
-        String cacheKey = "user:" + userId + ":profile";
-        UserProfileResponse cachedProfile = cacheManager.get(cacheKey, UserProfileResponse.class);
+        UserProfileResponse cachedProfile = cacheManager.get(profileCacheKey, UserProfileResponse.class);
         if (cachedProfile != null) {
             return cachedProfile;
         }
 
-        //cache에 없으면
+        // DB 조회
         User user = userRepository.findById(UserId.of(userId))
-                .orElseThrow(() -> UserNotFoundException.EXCEPTION);
+                .orElseThrow(() -> new IllegalStateException("User not found."));
+        UserProfileResponse profile = new UserProfileResponse(user);
 
-        int followerCount = followReadRepository.countFollowersByUserId(userId);
-        int followingCount = followReadRepository.countFollowingsByUserId(userId);
+        // 캐시에 저장
+        cacheManager.set(profileCacheKey, profile, 24 * 60); // 24시간 TTL
+        return profile;
+    }
 
-        UserProfileResponse profileResponse = new UserProfileResponse(user, followerCount, followingCount);
+    // Full UserProfile 통합 처리
+    public FullUserProfileResponse getFullUserProfile(String userId) {
+        UserProfileResponse profile = getUserProfile(userId); // 프로필 데이터
+        long followerCount = getFollowerCount(userId);        // 팔로워 수
+        long followingCount = getFollowingCount(userId);      // 팔로잉 수
 
-        cacheManager.set(cacheKey, profileResponse, 600); // 10시간
+        return new FullUserProfileResponse(profile, followerCount, followingCount);
+    }
 
-        return profileResponse;
+    // Follower Count 캐싱 처리
+    public long getFollowerCount(String userId) {
+        String followerCountCacheKey = "user:" + userId + ":followerCount";
+
+        Integer cachedCount = cacheManager.get(followerCountCacheKey, Integer.class);
+        if (cachedCount != null) {
+            return cachedCount;
+        }
+
+        // DB 조회 및 캐시 저장
+        long followerCount = followReadRepository.countFollowersByUserId(userId);
+        cacheManager.set(followerCountCacheKey, followerCount, 10); // 10분 TTL
+        return followerCount;
+    }
+
+    // Following Count 캐싱 처리
+    public long getFollowingCount(String userId) {
+        String followingCountCacheKey = "user:" + userId + ":followingCount";
+
+        Integer cachedCount = cacheManager.get(followingCountCacheKey, Integer.class);
+        if (cachedCount != null) {
+            return cachedCount;
+        }
+
+        // DB 조회 및 캐시 저장
+        long followingCount = followReadRepository.countFollowingsByUserId(userId);
+        cacheManager.set(followingCountCacheKey, followingCount, 10); // 10분 TTL
+        return followingCount;
     }
 
 

--- a/module-application/src/main/java/com/wsws/moduleapplication/user/service/UserQueryService.java
+++ b/module-application/src/main/java/com/wsws/moduleapplication/user/service/UserQueryService.java
@@ -2,8 +2,7 @@ package com.wsws.moduleapplication.user.service;
 
 import com.wsws.moduleapplication.user.dto.FullUserProfileResponse;
 import com.wsws.moduleapplication.user.dto.UserProfileResponse;
-import com.wsws.moduleapplication.user.exception.UserNotFoundException;
-import com.wsws.moduleinfra.cache.CacheManager;
+import com.wsws.moduledomain.cache.CacheManager;
 import com.wsws.moduledomain.user.User;
 import com.wsws.moduledomain.user.repo.UserRepository;
 import com.wsws.moduledomain.user.vo.UserId;

--- a/module-domain/src/main/java/com/wsws/moduledomain/cache/CacheManager.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/cache/CacheManager.java
@@ -1,4 +1,4 @@
-package com.wsws.moduleinfra.cache;
+package com.wsws.moduledomain.cache;
 
 public interface CacheManager {
 

--- a/module-domain/src/main/java/com/wsws/moduledomain/follow/UserRecommendationRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/follow/UserRecommendationRepository.java
@@ -1,7 +1,6 @@
-package com.wsws.moduledomain.recommendation.repo;
+package com.wsws.moduledomain.follow;
 
-import com.wsws.moduledomain.recommendation.UserRecommendation;
-import com.wsws.moduledomain.user.vo.UserInterest;
+import com.wsws.moduledomain.follow.vo.UserRecommendation;
 
 import java.util.List;
 

--- a/module-domain/src/main/java/com/wsws/moduledomain/follow/vo/UserRecommendation.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/follow/vo/UserRecommendation.java
@@ -1,4 +1,4 @@
-package com.wsws.moduledomain.recommendation;
+package com.wsws.moduledomain.follow.vo;
 
 import lombok.Value;
 

--- a/module-domain/src/main/java/com/wsws/moduledomain/recommendation/repo/UserRecommendationRepository.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/recommendation/repo/UserRecommendationRepository.java
@@ -6,5 +6,6 @@ import com.wsws.moduledomain.user.vo.UserInterest;
 import java.util.List;
 
 public interface UserRecommendationRepository {
-    List<UserRecommendation> findTopRecommendations(String userId, List<UserInterest> userInterests, int limit);
+    List<UserRecommendation> findTopRecommendations(String userId, List<Long> interestCategoryIds, int limit);
+    List<UserRecommendation> findGeneralRecommendations(String userId, int limit);
 }

--- a/module-domain/src/main/java/com/wsws/moduledomain/user/vo/Password.java
+++ b/module-domain/src/main/java/com/wsws/moduledomain/user/vo/Password.java
@@ -11,7 +11,6 @@ import java.util.regex.Pattern;
 
 @EqualsAndHashCode
 @Getter
-
 public class Password {
     public static final String REGEX = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[$@$!%*?&])[A-Za-z\\d$@$!%*?&]{8,20}";
     private static final Pattern PATTERN = Pattern.compile(REGEX); // 정적 필드로 사용 -> 대량 검증시 성능 저하 덜함

--- a/module-infra/src/main/java/com/wsws/moduleinfra/cache/RedisCacheManager.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/cache/RedisCacheManager.java
@@ -1,5 +1,6 @@
 package com.wsws.moduleinfra.cache;
 
+import com.wsws.moduledomain.cache.CacheManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.data.redis.core.RedisTemplate;

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/follow/UserRecommendationRepositoryImpl.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/follow/UserRecommendationRepositoryImpl.java
@@ -1,11 +1,9 @@
 package com.wsws.moduleinfra.repo.follow;
 
 import com.querydsl.core.types.Projections;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.wsws.moduledomain.recommendation.UserRecommendation;
-import com.wsws.moduledomain.recommendation.repo.UserRecommendationRepository;
-import com.wsws.moduledomain.user.vo.UserInterest;
+import com.wsws.moduledomain.follow.vo.UserRecommendation;
+import com.wsws.moduledomain.follow.UserRecommendationRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 

--- a/module-infra/src/main/java/com/wsws/moduleinfra/repo/follow/UserRecommendationRepositoryImpl.java
+++ b/module-infra/src/main/java/com/wsws/moduleinfra/repo/follow/UserRecommendationRepositoryImpl.java
@@ -21,16 +21,10 @@ public class UserRecommendationRepositoryImpl implements UserRecommendationRepos
 
     private final JPAQueryFactory queryFactory;
 
-
     @Override
-    public List<UserRecommendation> findTopRecommendations(String userId, List<UserInterest> userInterests, int limit) {
-
-        List<Long> interestCategoryIds = userInterests.stream()
-                .map(userInterest -> userInterest.getCategoryId().getValue())
-                .toList();
-
-        List<UserRecommendation> commonInterestUsers = queryFactory
-                .select(Projections.constructor( // UserRecomendation vo 형식으로 projection
+    public List<UserRecommendation> findTopRecommendations(String userId, List<Long> interestCategoryIds, int limit) {
+        return queryFactory
+                .select(Projections.constructor(
                         UserRecommendation.class,
                         userEntity.id,
                         userEntity.nickname,
@@ -38,45 +32,32 @@ public class UserRecommendationRepositoryImpl implements UserRecommendationRepos
                         followEntity.id.followerId.count().as("followerCount")
                 ))
                 .from(userEntity)
-                .leftJoin(userInterestEntity).on(userEntity.id.eq(userInterestEntity.user.id))
-                .leftJoin(followEntity).on(userEntity.id.eq(followEntity.id.followeeId))
+                .innerJoin(userInterestEntity).on(userEntity.id.eq(userInterestEntity.user.id))
+                .innerJoin(followEntity).on(userEntity.id.eq(followEntity.id.followeeId))
                 .where(userEntity.id.ne(userId)
                         .and(userInterestEntity.category.id.in(interestCategoryIds)))
                 .groupBy(userEntity.id)
                 .orderBy(followEntity.id.followerId.count().desc())
                 .limit(limit)
                 .fetch();
-        if (commonInterestUsers.size() < limit) { // 동일한 사람이 다 안채워지면 유사도 높은 사람
-            int remaining = limit - commonInterestUsers.size();
-            List<UserRecommendation> generalUsers = queryFactory
-                    .select(Projections.constructor(
-                            UserRecommendation.class,
-                            userEntity.id,
-                            userEntity.nickname,
-                            userEntity.profileImage,
-                            queryFactory
-                                    .select(followEntity.id.followerId.count())
-                                    .from(followEntity)
-                                    .where(followEntity.id.followeeId.eq(userEntity.id))
-                    ))
-                    .from(userEntity)
-                    .where(userEntity.id.ne(userId)
-                            .and(userEntity.id.notIn(
-                                    commonInterestUsers.stream()
-                                            .map(UserRecommendation::getUserId)
-                                            .toList())))
-                    .orderBy(Expressions.asNumber(
-                            queryFactory
-                                    .select(followEntity.id.followerId.count())
-                                    .from(followEntity)
-                                    .where(followEntity.id.followeeId.eq(userEntity.id))
-                    ).desc())
-                    .limit(remaining)
-                    .fetch();
+    }
 
-            commonInterestUsers.addAll(generalUsers);
-        }
-
-        return commonInterestUsers;
+    @Override
+    public List<UserRecommendation> findGeneralRecommendations(String userId, int limit) {
+        return queryFactory
+                .select(Projections.constructor(
+                        UserRecommendation.class,
+                        userEntity.id,
+                        userEntity.nickname,
+                        userEntity.profileImage,
+                        followEntity.id.followerId.count().as("followerCount")
+                ))
+                .from(userEntity)
+                .leftJoin(followEntity).on(userEntity.id.eq(followEntity.id.followeeId))
+                .where(userEntity.id.ne(userId))
+                .groupBy(userEntity.id)
+                .orderBy(followEntity.id.followerId.count().desc())
+                .limit(limit)
+                .fetch();
     }
 }


### PR DESCRIPTION
## 📌 과제 설명 
쿼리 최적화 및 캐싱 단위 변경

## 👩‍💻 요구 사항과 구현 내용 
- 유저 프로필 조회시 followerCount, followingCount, 나머지 유저 프로필 정보로 나누어서 캐싱하도록 변경
- 팔로우 추천 조회시, 동일한 관심사의 사용자가 없을 때를 처리하는 조건을 infra -> application 모듈로 이동
- 추천 도메인 follow 애그리거트로 이동
- left join -> inner join으로 변경(인덱스 사용 제한 고려)
- DB에 follower_id, followee_id와 user-userinterest 복합키 인덱스 추가


